### PR TITLE
Fix allow response

### DIFF
--- a/includes/Location.hpp
+++ b/includes/Location.hpp
@@ -42,7 +42,7 @@ public:			//getters
 		std::string					getroot() const;
 		std::string					getautoindex() const;
 		std::string					getlocationmatch() const;
-		std::vector<e_method>		getallowmethods() const;
+		std::string					getallowedmethods() const;
 		std::string					getindex() const;
 		std::vector<std::string>	getindexes() const;
 		std::vector<std::string>	getcgiallowedextensions() const;

--- a/includes/ResponseHandler.hpp
+++ b/includes/ResponseHandler.hpp
@@ -34,7 +34,7 @@ public:
 	std::string&	handleRequest(request_s& request);
 	void		handleBody(request_s& request);
 	void		handleStatusCode(request_s& request);
-	void		handleALLOW( );
+	void		handleALLOW(request_s& request);
 	void		handleCONTENT_LANGUAGE( );
 	void		handleCONTENT_LENGTH( );
 	void		handleCONTENT_LOCATION( );

--- a/srcs/Location.cpp
+++ b/srcs/Location.cpp
@@ -86,7 +86,6 @@ void	Location::setroot(const std::string& in) {
 std::string					Location::getroot() const { return this->_root; }
 std::string					Location::getautoindex() const { return this->_autoindex; }
 std::string					Location::getlocationmatch() const { return this->_location_match; }
-std::vector<e_method>		Location::getallowmethods() const { return this->_allow_method; }
 std::vector<std::string>	Location::getindexes() const { return this->_indexes; }
 std::vector<std::string>	Location::getcgiallowedextensions() const { return this->_cgi_allowed_extensions; }
 std::string					Location::geterrorpage() const { return this->getroot() + '/' + this->_error_page; }
@@ -94,6 +93,15 @@ long unsigned int			Location::getmaxbody() const { return this->_maxBody; }
 std::string					Location::getindex() const { return this->_indexes[0]; }
 std::string					Location::getdefaultcgipath() const { return this->_default_cgi_path; }
 
+std::string					Location::getallowedmethods() const {
+	std::string ret("Allow:");
+	for (size_t i = 0; i < this->_allow_method.size(); ++i) {
+		if (i > 0)
+			ret += ',';
+		ret += " " + methodAsString(this->_allow_method[i]);
+	}
+	return (ret);
+}
 bool		Location::checkifMethodAllowed(const e_method& meth) const {
 	for (std::vector<e_method>::const_iterator it = this->_allow_method.begin(); it != this->_allow_method.end(); ++it)
 		if (*it == meth)
@@ -145,11 +153,7 @@ std::ostream&	operator<<(std::ostream& o, const Location& x) {
 	o	<< "Location block \"" << x.getlocationmatch() << "\":" << std::endl
 		<< "\troot folder: \"" << x.getroot() << "\"" << std::endl
 		<< "\tautoindex is: \"" << x.getautoindex() << "\"" << std::endl;
-	o	<< "\tallowed methods:";
-	meths = x.getallowmethods();
-	for (size_t i = 0; i < meths.size(); i++)
-		o << " \"" << methodAsString(meths[i]) << "\"";
-	o << std::endl;
+	o	<< '\t' << x.getallowedmethods() << std::endl;
 	o	<< "\tindexes:";
 	v = x.getindexes();
 	for (size_t i = 0; i < v.size(); i++)

--- a/srcs/ResponseHandler.cpp
+++ b/srcs/ResponseHandler.cpp
@@ -319,8 +319,8 @@ void	ResponseHandler::handleStatusCode(request_s& request) {
 	_response += _status_codes[_status_code];
 }
 
-void ResponseHandler::handleALLOW() {
-	_header_vals[ALLOW] = "GET, HEAD, POST, PUT";
+void ResponseHandler::handleALLOW(request_s& request) {
+	_header_vals[ALLOW] = request.server->matchlocation(request.uri).getallowedmethods();
 	_response += "Allow: ";
 	_response += _header_vals[ALLOW];
 	_response += "\r\n";


### PR DESCRIPTION
https://youtu.be/0vsnwUJjunU
close #36 

we used to always return "Allow: GET, HEAD, POST, PUT" even if those methods werent allowed...