### PR TITLE
Closing socket fd's when shutting down server or restarting.

### DIFF
--- a/configfiles/42test.conf
+++ b/configfiles/42test.conf
@@ -1,6 +1,6 @@
 server {
 	port    8080 # changed it from 80, as on my linux laptop my user didnt have root, and thus cant bind to ports <= 1024
-	host    127.0.0.1
+	host    localhost
 	server_name     Webserv #optional to set
 	error_page      error.html
 	max_filesize	260144

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -138,9 +138,7 @@ void Connection::stopServer() {
 	std::vector<Server*>::iterator	sit;
 	std::vector<Client*>::iterator	cit;
 	for (sit = _servers.begin(); sit != _servers.end(); ++sit) {
-		close((*sit)->getSocketFd());
 		for (cit = (*sit)->_connections.begin(); cit != (*sit)->_connections.end(); ++cit) {
-			close((*cit)->fd);
 			delete *cit;
 		}
 		(*sit)->_connections.clear();

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -138,7 +138,9 @@ void Connection::stopServer() {
 	std::vector<Server*>::iterator	sit;
 	std::vector<Client*>::iterator	cit;
 	for (sit = _servers.begin(); sit != _servers.end(); ++sit) {
+		close((*sit)->getSocketFd());
 		for (cit = (*sit)->_connections.begin(); cit != (*sit)->_connections.end(); ++cit) {
+			close((*cit)->fd);
 			delete *cit;
 		}
 		(*sit)->_connections.clear();
@@ -152,7 +154,7 @@ void Connection::stopServer() {
 	FD_ZERO(&_writeFds);
 	FD_ZERO(&_readFdsBak);
 	FD_ZERO(&_writeFdsBak);
-	std::cerr << _GREEN "Server stopped gracefully.\n" << _END;
+	std::cerr << _GREEN "\nServer stopped gracefully.\n" << _END;
 }
 
 void Connection::loadConfiguration() {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -35,6 +35,7 @@ Server::Server(int fd) : _port(80), _maxfilesize(1000000),
 }
 
 Server::~Server() {
+	close(_socketFd);
 }
 
 Server::Server(const Server& x) : _port(), _maxfilesize(), _fd(), _socketFd(), addr() {


### PR DESCRIPTION
This fixes #50. @pde-bakk could you check if this is doing anything that might be a problem with how you implemented Graceful shutdown?